### PR TITLE
Ignore vendor folders on lint

### DIFF
--- a/tasks/quality.js
+++ b/tasks/quality.js
@@ -33,7 +33,8 @@ module.exports = function(grunt) {
     '!<%= config.srcPaths.drupal %>/**/*.features.*inc',
     '!<%= config.srcPaths.drupal %>/**/*.pages_default.inc',
     '!<%= config.srcPaths.drupal %>/**/*.panelizer.inc',
-    '!<%= config.srcPaths.drupal %>/**/*.strongarm.inc'
+    '!<%= config.srcPaths.drupal %>/**/*.strongarm.inc',
+    '!<%= config.srcPaths.drupal %>/**/vendor/**'
   ];
 
   grunt.config('phplint', {


### PR DESCRIPTION
If a module using composer locally, lint errors out as it goes through some the vendor folder in some cases.
